### PR TITLE
Upgrade keymap's selector to use Shadow DOM's name

### DIFF
--- a/keymaps/block-travel.cson
+++ b/keymaps/block-travel.cson
@@ -1,4 +1,4 @@
-'.editor':
+'atom-text-editor':
   'alt-up': 'block-travel:move-up'
   'alt-down': 'block-travel:move-down'
   'alt-shift-up': 'block-travel:select-up'


### PR DESCRIPTION
Sorry I forgot to check keymap.cson in previous PR https://github.com/leejarvis/block-travel/pull/8. Could you merge and republish this?