### PR TITLE
Fix for wrapped lines

### DIFF
--- a/lib/block-travel.coffee
+++ b/lib/block-travel.coffee
@@ -3,7 +3,7 @@ blockTravel = (editor, direction, select) ->
   lineCount = editor.getScreenLineCount()
 
   for cursor in editor.getCursors()
-    row   = cursor.getBufferRow()
+    row   = cursor.getScreenRow()
     count = 0
 
     loop

--- a/spec/block-travel-spec.coffee
+++ b/spec/block-travel-spec.coffee
@@ -69,6 +69,35 @@ describe "BlockTravel", ->
         expect(editor.getCursorBufferPosition()).toEqual([9, 0])
         expect(editor.getCursorScreenPosition()).toEqual([6, 0])
 
+    describe "with soft wrapped rows", ->
+      beforeEach ->
+        editor = atom.workspace.getActiveTextEditor()
+        editor.setSoftWrapped(true)
+        editor.setEditorWidthInChars(80)
+        editor.setDefaultCharWidth(8)
+        editor.setText """
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        """
+
+      it "properly handles jumping over soft wrapped blocks", ->
+        editor.setCursorBufferPosition([0, 0])
+        blockTravel(editor, "down", false)
+        expect(editor.getCursorBufferPosition()).toEqual([1, 0])
+
+        blockTravel(editor, "down", false)
+        expect(editor.getCursorBufferPosition()).toEqual([3, 0])
+        expect(editor.getCursorScreenPosition()).toEqual([7, 0])
+
+        blockTravel(editor, "up", false)
+        expect(editor.getCursorBufferPosition()).toEqual([1, 0])
+
+        blockTravel(editor, "up", false)
+        expect(editor.getCursorBufferPosition().row).toEqual(0)
+
     describe "with multiple cursors", ->
       beforeEach ->
         waitsForPromise ->


### PR DESCRIPTION
As of 1.0.3 (81ed8bf28e07e126a67bc541cf80dfee413359f7), it totally gets the gaps wrong when there are soft wrapped lines. This fixes it + adds a test.