### PR TITLE
Remove unnecessary workspace.opens()

### DIFF
--- a/spec/block-travel-spec.coffee
+++ b/spec/block-travel-spec.coffee
@@ -37,9 +37,6 @@ describe "BlockTravel", ->
 
     describe "with folded rows", ->
       beforeEach ->
-        waitsForPromise ->
-          atom.workspace.open()
-
         editor = atom.workspace.getActiveTextEditor()
         editor.setText """
           var quicksort = function () {
@@ -71,9 +68,6 @@ describe "BlockTravel", ->
 
     describe "with multiple cursors", ->
       beforeEach ->
-        waitsForPromise ->
-          atom.workspace.open()
-
         editor = atom.workspace.getActiveTextEditor()
         editor.setText """
           console.log("Hello World");


### PR DESCRIPTION
Dont need these as the open is called in the orig `beforeEach`
